### PR TITLE
Several Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.pyc
+settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *.pyc
 settings.json
+.DS_Store

--- a/guide.py
+++ b/guide.py
@@ -11,20 +11,27 @@ initdict = {
 def guide(usr: str):
     print(f":)   嗨，初次见面！{usr}")
     time.sleep(2)
-    print("ModSyncer将进行一些准备工作，请坐和放宽...")
+    print("ModSyncer 将进行一些准备工作，请坐和放宽...")
     print("========== 这不会需要很长时间 ==========")
     f = open('settings.json', 'w')
-    os.system("cls")
-    print("[ModSyncer Guide] 欢迎您使用ModSyncer！ModSyncer是一款旨在方便地同步您与服务器Mods文件夹的程序")
-    print("[ModSyncer Guide] 如您希望跳过使用向导，请输入[C]以退出或按任意键继续向导")
-    print("========== 如果您选择了跳过向导，ModSyncer将采用推荐设置完成初始化 ==========")
-    inp = input()
-    os.system("cls")
-    if inp != 'C' or inp != 'c':
+    
+    print("[ModSyncer Guide] 欢迎您使用ModSyncer！ModSyncer是一款旨在方便地同步您与"
+        "服务器Mods文件夹的程序")
+    # print("[ModSyncer Guide] 如您希望跳过使用向导，请输入[C]以退出或按任意键继续向导")
+    print("========== 如果您选择了跳过向导，ModSyncer 将采用推荐设置完成初始化 ======="
+        "==")
+    inp = input("[ModSyncer Guide] 是否跳过向导？(Y/N) ")
+    
+    if os.name == 'nt':
+        os.system('cls')
+    elif os.name == 'posix':
+        os.system('clear')
+    
+    if inp.lower() == 'n':
         print("[ModSyncer Guide] 首先，让我们来选择使用何种同步模式：")
-        print("[1] 由同步服务器来决定 [推荐]")
+        print("[1] 由同步服务器来决定（推荐）")
         print("[2] 每次同步都删除文件夹下所有文件")
-        print("[3] 每次同步只删除文件夹下以 [r] 开头的文件")
+        print("[3] 每次同步只删除文件夹下以 r 开头的文件")
         slt = input("请输入您所选选项的编号：  ")
         if slt == '1':
             print("[ModSyncer Guide] 同步模式已设为[由同步服务器来决定]")
@@ -32,13 +39,14 @@ def guide(usr: str):
             print("[ModSyncer Guide] 同步模式已设为[每次同步都删除文件夹下所有文件]")
             initdict["sync_mode"] = 2
         elif slt == '3':
-            print("[ModSyncer Guide] 同步模式已设为[每次同步只删除文件夹下以 [r] 开头的文件]")
+            print("[ModSyncer Guide] 同步模式已设为[每次同步只删除文件夹下以 [r] 开头"
+                "的文件]")
             initdict["sync_mode"] = 3
         else:
             print("[ModSyncer Guide] 使用推荐设置，同步模式已设为[由同步服务器来决定]")
         print("[ModSyncer Guide] 很好，让我们继续下一个设置吧")
-        print("[ModSyncer Guide] 然后，您希望ModSyncer启用自动更新吗：")
-        print("[1] 启用自动更新 [推荐]")
+        print("[ModSyncer Guide] 然后，您希望 ModSyncer 启用自动更新吗：")
+        print("[1] 启用自动更新（推荐）")
         print("[2] 禁用自动更新")
         slt = input("请输入您所选选项的编号：  ")
         if slt == '1':
@@ -49,6 +57,11 @@ def guide(usr: str):
 
     json.dump(initdict, f)
     f.close()
-    os.system("cls")
+    
+    if os.name == 'nt':
+        os.system('cls')
+    elif os.name == 'posix':
+        os.system('clear')
+    
     print("[ModSyncer Guide] 好的，您已经完成了全部初始设定，请开始使用吧！")
     return

--- a/modsyncer.py
+++ b/modsyncer.py
@@ -1,23 +1,49 @@
+# Automatically install missing dependencies, English support, Linux support.
 from downloader import downloader
 import os
 import time
 import sys
 import getpass
 import json
+import subprocess
+import pkg_resources
 from guide import guide
 from updater import updater
 
+if os.name == 'nt':
+    os.system('cls')
+elif os.name == 'posix':
+    os.system('clear')
+time.sleep(1)
+
+required = {'requests'}
+installed = {pkg.key for pkg in pkg_resources.working_set}
+missing = required - installed
+
+if missing:
+    python = sys.executable
+    subprocess.check_call(
+        [python, '-m', 'pip', 'install', *missing],
+        stdout=subprocess.DEVNULL
+    )
+# Install missing dependencies. 安装依赖
+
+if os.name == 'nt':
+    arg = '\\'
+elif os.name == 'posix':
+    arg = '/'
+
 exedir = os.path.realpath(sys.argv[0])
-dirct = exedir.split("\\")
+dirct = exedir.split(arg)
 exename = dirct[-1].strip()
 exedir = exedir.replace(dirct[-1].strip(), '')
 filelist = os.listdir(exedir)
-# 获取程序目录
+# 获取程序目录 Get program directory.
 
 ver = 3.5
 if os.path.isfile("upgrade.bat"):
     os.remove("upgrade.bat")
-# 删除升级脚本
+# 删除升级脚本 Remove update script.
 
 try:
     f = open("settings.json", 'r')
@@ -27,8 +53,8 @@ except FileNotFoundError:
 
 settings = json.load(f)
 
-print(f"================= [MobSyncer V{ver}] ===================")
-print("======Powered By BiDuang & AsakiRain | [c] 2021 ========")
+print(f"================== [MobSyncer v{ver}] ====================")
+print("======Powered by BiDuang & AsakiRain | [c] 2021 ========")
 print(f"欢迎！ {getpass.getuser()}")
 time.sleep(1)
 
@@ -36,7 +62,7 @@ updater(ver, exedir, settings['auto_update'])
 
 usrinp = input("[ModSyncer] 输入[C]进入同步模式，输入[S]进入偏好设置:\n")
 
-if usrinp == 'C' or usrinp == 'c':
+if usrinp.lower() == 'c':
 
     print("同步服务器已设置为：AsakiRain的Mod分发服务器")
     if settings['sync_mode'] == 1:
@@ -46,27 +72,34 @@ if usrinp == 'C' or usrinp == 'c':
     elif settings['sync_mode'] == 3:
         info = '当前同步模式为[每次同步只删除文件夹下以 [r] 开头的文件]'
 
-    print(f"[ModSyncer] 同步前，请您确认：")
-    print("1. ModSyncer只提供文件传输，不存储任何文件，也不为文件的稳定性或版权作任何担保")
+    print("[ModSyncer] 同步前，请您确认：")
+    print("1. ModSyncer只提供文件传输，不存储任何文件，也不为文件的稳定性或版权作任何担"
+        "保")
     print(f"2. {info}，请您确认程序放置的目录是您的Mods目录：\n{exedir}")
     if settings['sync_mode'] == 2:
-        print(f"3. 注意！您选择了[每次同步都删除文件夹下所有文件]，如果继续，您将失去文件夹下全部文件！")
-    st = input('当您知悉以上信息并准备好开始同步，请输入[Y]:\n')
+        print(f"3. 注意！您选择了[每次同步都删除文件夹下所有文件]，如果继续，您将失去文件"
+            "夹下全部文件！")
+    st = input('当您知悉以上信息并准备好开始同步，请输入[Y] (按其他键取消同步): ')
 
-    if st == 'Y' or st == 'y':
-        os.system("cls")
+    if st.lower() == 'y':
+        
+        if os.name == 'nt':
+            os.system('cls')
+        elif os.name == 'posix':
+            os.system('clear')
+        
         print("[提示] 正在进行同步前的准备工作，这不会需要很长时间...")
         sum = 0
         for file in filelist:
             if settings['sync_mode'] == 2:
                 if file != exename and file != 'settings.json':
                     print(f"[提示] 正在从 {exedir} 抹除 {file} ...")
-                    os.remove(f"{exedir}\\{file}")
+                    os.remove(f"{exedir}/{file}")
                     sum += 1
             if settings['sync_mode'] == 3 or settings['sync_mode'] == 1:
                 if file.startswith('[r]'):
                     print(f"[提示] 正在从 {exedir} 抹除 {file} ...")
-                    os.remove(f"{exedir}\\{file}")
+                    os.remove(f"{exedir}/{file}")
                     sum += 1
 
         print(f"[ModSyncer] 清理工作已完成，共删除了{sum}个文件，同步将很快开始")
@@ -78,9 +111,9 @@ if usrinp == 'C' or usrinp == 'c':
     else:
         print("[ModSyncer] 用户取消了同步，请按任意键退出")
 
-elif usrinp == 'S' or usrinp == 's':
+elif usrinp.lower() == 's':
     print("设置选项还在开发中...您可以通过删除[settings.json]以重新初始化")
     print("按任意键退出")
 else:
-    print("无效输入，按任意键退出")
-anyk = input("\n")
+    print("无效输入！请按任意键退出。")
+anyk = input()


### PR DESCRIPTION
# Several Updates
## 1. Automatically Installing Missing Dependencies
Since the `requests` module isn't included in the Python Standard Library but a dependency thereof, I added some lines of code as follows to check whether the user has had `requests` installed or not and install it if they hasn't.
```python
required = {'requests'}
installed = {pkg.key for pkg in pkg_resources.working_set}
missing = required - installed

if missing:
    python = sys.executable
    subprocess.check_call(
        [python, '-m', 'pip', 'install', *missing],
        stdout=subprocess.DEVNULL
    )
```

## 2. Supporting Linux-Based Operating Systems
File paths are different between Windows and Linux systems for the former uses backslashes (\\) and the latter use forward slashes (/) when displaying them.

Single backslashes are not allowed in python for they might be confused with '\n's or '\t's while forward slashes are allowed for both Windows and Linux systems. Therefore, the simplest way to make the program Linux-supporting is to switch the '\\\\'s in the original to '/'s as in `os.remove(f"{exedir}/{file}")`.

However, considering that the `os.path.realpath(sys.argv[0])` function may return a double-backslash-separated file path, I added
```python
if os.name == 'nt':
    arg = '\\'
elif os.name == 'posix':
    arg = '/'
```
in front of 
```python
exedir = os.path.realpath(sys.argv[0])
dirct = exedir.split(arg)
```
to make sure the gotten file path is correctly separated and stored into the list `dirct`.

At the mean time, some OS commands varies from Windows to Linux, too. (For instance, the command for clearing the terminal window which is used frequently in the program.)
```python
if os.name == 'nt':
    os.system('cls')
elif os.name == 'posix':
    os.system('clear')
```

## 3. Optimized the Coding and Fixed a Hilarious Bug
In the original code, after asking the user to type in, if statements like `if inp == 'N' or inp == 'n':` is used to check whether the answer matches the choices. To increase the conciseness and the readability of the code, `if inp.lower() == 'n':` would be much better.

What is hilarious is that, after asking the user whether to skip the guide at the first time, the original code regards 'Y' as 'do not skip' and 'N' as 'skip'. ~~*足以说明阿炳事屑(bushi*~~